### PR TITLE
Polish public interface for `dbkit` (root) and `dbrutil` packages

### DIFF
--- a/dbrutil/composite_event_receiver.go
+++ b/dbrutil/composite_event_receiver.go
@@ -10,7 +10,8 @@ import (
 	"github.com/gocraft/dbr/v2"
 )
 
-// CompositeEventReceiver represents a composition of event receivers from dbr package and implements Composite design pattern.
+// CompositeEventReceiver represents a composition of event receivers from dbr package
+// and implements a Composite design pattern.
 type CompositeEventReceiver struct {
 	Receivers []dbr.EventReceiver
 }

--- a/dbrutil/slow_query_log_event_receiver.go
+++ b/dbrutil/slow_query_log_event_receiver.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gocraft/dbr/v2"
 )
 
-// SlowQueryLogEventReceiverOpts consists options for SlowQueryLogEventReceiver.
+// SlowQueryLogEventReceiverOpts contains options for SlowQueryLogEventReceiver.
 type SlowQueryLogEventReceiverOpts struct {
 	AnnotationPrefix   string
 	AnnotationModifier func(string) string
@@ -29,9 +29,10 @@ type SlowQueryLogEventReceiver struct {
 	annotationModifier func(string) string
 }
 
-// NewSlowQueryLogEventReceiverWithOpts creates a new SlowQueryLogEventReceiver with additinal options.
-func NewSlowQueryLogEventReceiverWithOpts(logger log.FieldLogger, longQueryTime time.Duration,
-	options SlowQueryLogEventReceiverOpts) *SlowQueryLogEventReceiver {
+// NewSlowQueryLogEventReceiverWithOpts creates a new SlowQueryLogEventReceiver with additional options.
+func NewSlowQueryLogEventReceiverWithOpts(
+	logger log.FieldLogger, longQueryTime time.Duration, options SlowQueryLogEventReceiverOpts,
+) *SlowQueryLogEventReceiver {
 	return &SlowQueryLogEventReceiver{
 		NullEventReceiver:  &dbr.NullEventReceiver{},
 		logger:             logger,

--- a/metrics.go
+++ b/metrics.go
@@ -18,8 +18,8 @@ const PrometheusMetricsLabelQuery = "query"
 // DefaultQueryDurationBuckets is default buckets into which observations of executing SQL queries are counted.
 var DefaultQueryDurationBuckets = []float64{0.001, 0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 
-// MetricsCollectorOpts represents an options for PrometheusMetrics.
-type MetricsCollectorOpts struct {
+// PrometheusMetricsOpts represents an options for PrometheusMetrics.
+type PrometheusMetricsOpts struct {
 	// Namespace is a namespace for metrics. It will be prepended to all metric names.
 	Namespace string
 
@@ -44,11 +44,11 @@ type PrometheusMetrics struct {
 
 // NewPrometheusMetrics creates a new metrics collector.
 func NewPrometheusMetrics() *PrometheusMetrics {
-	return NewPrometheusMetricsWithOpts(MetricsCollectorOpts{})
+	return NewPrometheusMetricsWithOpts(PrometheusMetricsOpts{})
 }
 
 // NewPrometheusMetricsWithOpts is a more configurable version of creating PrometheusMetrics.
-func NewPrometheusMetricsWithOpts(opts MetricsCollectorOpts) *PrometheusMetrics {
+func NewPrometheusMetricsWithOpts(opts PrometheusMetricsOpts) *PrometheusMetrics {
 	queryDurationBuckets := opts.QueryDurationBuckets
 	if queryDurationBuckets == nil {
 		queryDurationBuckets = DefaultQueryDurationBuckets

--- a/metrics.go
+++ b/metrics.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type MetricsCollector interface {
-	ObserveQueryDuration(query string, duration time.Duration)
-}
-
 // PrometheusMetricsLabelQuery is a label name for SQL query in Prometheus metrics.
 const PrometheusMetricsLabelQuery = "query"
 


### PR DESCRIPTION
* Receive interface instead of concrete struct in `dbrutil.NewSlowQueryLogEventReceiver()`.
* Rename `MetricsCollectorOpts` to `PrometheusMetricsOpts` for consistency.